### PR TITLE
Fix Locals Screen Rendering and Firestore Data Mapping

### DIFF
--- a/lib/models/locals_record.dart
+++ b/lib/models/locals_record.dart
@@ -42,7 +42,7 @@ class LocalsRecord {
 
   // Getter aliases for compatibility with backend schema expectations
   String get localUnion => localNumber;
-  String? get phone => contactPhone;
+  String get phone => contactPhone;
   String get email => contactEmail;
   
   // Extract city and state from location string
@@ -61,15 +61,21 @@ class LocalsRecord {
 
   factory LocalsRecord.fromFirestore(DocumentSnapshot doc) {
     final data = doc.data() as Map<String, dynamic>;
+    
+    // Build location from city and state
+    final city = data['city'] ?? '';
+    final state = data['state'] ?? '';
+    final location = city.isNotEmpty && state.isNotEmpty ? '$city, $state' : '';
+    
     return LocalsRecord(
       id: doc.id,
-      localNumber: data['localNumber'] ?? '',
-      localName: data['localName'] ?? '',
+      localNumber: data['local_union']?.toString() ?? '',
+      localName: data['local_name'] ?? 'IBEW Local ${data['local_union'] ?? ''}',
       classification: data['classification'],
-      location: data['location'] ?? '',
+      location: location,
       address: data['address'],
-      contactEmail: data['contactEmail'] ?? '',
-      contactPhone: data['contactPhone'] ?? '',
+      contactEmail: data['email'] ?? '',
+      contactPhone: data['phone'] ?? '',
       website: data['website'],
       memberCount: data['memberCount'] ?? 0,
       specialties: List<String>.from(data['specialties'] ?? []),

--- a/lib/providers/app_state_provider.dart
+++ b/lib/providers/app_state_provider.dart
@@ -386,30 +386,7 @@ class AppStateProvider extends ChangeNotifier {
       final snapshot = await localsStream.first;
       
       final newLocals = snapshot.docs.map((doc) {
-        final data = doc.data() as Map<String, dynamic>;
-        // Map Firestore fields to LocalsRecord fields
-        final city = data['city'] ?? '';
-        final state = data['state'] ?? '';
-        final location = city.isNotEmpty && state.isNotEmpty ? '$city, $state' : '';
-        
-        return LocalsRecord(
-          id: doc.id,
-          localNumber: data['local_union'] ?? doc.id, // Use local_union from Firestore
-          localName: data['local_name'] ?? 'IBEW Local ${data['local_union'] ?? doc.id}', // Generate name if not present
-          classification: data['classification'],
-          location: location,
-          address: data['address'],
-          contactEmail: data['email'] ?? '', // Use email from Firestore
-          contactPhone: data['phone'] ?? '', // Use phone from Firestore
-          website: data['website'],
-          memberCount: data['member_count'] ?? 0,
-          specialties: (data['specialties'] as List?)?.cast<String>() ?? [],
-          isActive: data['is_active'] ?? true,
-          createdAt: data['created_at'] is Timestamp ? (data['created_at'] as Timestamp).toDate() : DateTime.now(),
-          updatedAt: data['updated_at'] is Timestamp ? (data['updated_at'] as Timestamp).toDate() : DateTime.now(),
-          reference: doc.reference,
-          rawData: data,
-        );
+        return LocalsRecord.fromFirestore(doc);
       }).toList();
       
       if (isRefresh) {
@@ -454,30 +431,7 @@ class AppStateProvider extends ChangeNotifier {
       final snapshot = await localsStream.first;
       
       final newLocals = snapshot.docs.map((doc) {
-        final data = doc.data() as Map<String, dynamic>;
-        // Map Firestore fields to LocalsRecord fields
-        final city = data['city'] ?? '';
-        final state = data['state'] ?? '';
-        final location = city.isNotEmpty && state.isNotEmpty ? '$city, $state' : '';
-        
-        return LocalsRecord(
-          id: doc.id,
-          localNumber: data['local_union'] ?? doc.id, // Use local_union from Firestore
-          localName: data['local_name'] ?? 'IBEW Local ${data['local_union'] ?? doc.id}', // Generate name if not present
-          classification: data['classification'],
-          location: location,
-          address: data['address'],
-          contactEmail: data['email'] ?? '', // Use email from Firestore
-          contactPhone: data['phone'] ?? '', // Use phone from Firestore
-          website: data['website'],
-          memberCount: data['member_count'] ?? 0,
-          specialties: (data['specialties'] as List?)?.cast<String>() ?? [],
-          isActive: data['is_active'] ?? true,
-          createdAt: data['created_at'] is Timestamp ? (data['created_at'] as Timestamp).toDate() : DateTime.now(),
-          updatedAt: data['updated_at'] is Timestamp ? (data['updated_at'] as Timestamp).toDate() : DateTime.now(),
-          reference: doc.reference,
-          rawData: data,
-        );
+        return LocalsRecord.fromFirestore(doc);
       }).toList();
       
       _locals.addAll(newLocals);

--- a/lib/screens/locals/locals_screen.dart
+++ b/lib/screens/locals/locals_screen.dart
@@ -355,14 +355,14 @@ class LocalCard extends StatelessWidget {
                     ),
                     const SizedBox(height: AppTheme.spacingSm),
                   ],
-                  if (local.phone?.isNotEmpty == true) ...[
+                  if (local.phone.isNotEmpty) ...[
                     _buildInfoRow(
                       context,
                       'Phone',
-                      local.phone!,
+                      local.phone,
                       Icons.phone_outlined,
                       canTap: true,
-                      onTap: () => _launchPhone(local.phone!),
+                      onTap: () => _launchPhone(local.phone),
                     ),
                     const SizedBox(height: AppTheme.spacingSm),
                   ],
@@ -558,7 +558,7 @@ class LocalDetailsDialog extends StatelessWidget {
                 // Details
                 _buildDetailRow('Classification', local.classification ?? 'Unknown'),
                 _buildDetailRow('Address', local.address ?? 'Not specified'),
-                _buildDetailRow('Phone', local.phone ?? 'Not specified'),
+                _buildDetailRow('Phone', local.phone.isNotEmpty ? local.phone : 'Not specified'),
                 _buildDetailRow('Email', local.email),
                 _buildDetailRow('Website', local.website ?? 'Not specified'),
                 const SizedBox(height: AppTheme.spacingLg),

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -148,7 +148,7 @@ class FirestoreService {
       limit = maxPageSize;
     }
     
-    Query query = localsCollection.orderBy('localUnion');
+    Query query = localsCollection.orderBy('local_union');
     
     // Apply geographic filtering if provided
     if (state != null && state.isNotEmpty) {
@@ -185,8 +185,8 @@ class FirestoreService {
       
       // Apply search filter
       query = query
-          .where('localUnion', isGreaterThanOrEqualTo: searchTerm.toLowerCase())
-          .where('localUnion', isLessThanOrEqualTo: '${searchTerm.toLowerCase()}\uf8ff')
+          .where('local_union', isGreaterThanOrEqualTo: searchTerm.toLowerCase())
+          .where('local_union', isLessThanOrEqualTo: '${searchTerm.toLowerCase()}\uf8ff')
           .limit(limit);
       
       return await query.get();


### PR DESCRIPTION
## Summary
- Fixes rendering issues on the Locals screen by ensuring proper data mapping and type handling
- Refactors LocalsRecord model to correctly parse Firestore data with updated field names and location formatting
- Updates AppStateProvider to use the centralized LocalsRecord.fromFirestore factory for consistency
- Corrects Firestore queries to use the proper field names for ordering and filtering
- Improves UI handling of phone number display and interaction in Locals screen components

## Changes

### Data Model and Firestore Integration
- Updated `LocalsRecord` to:
  - Use correct Firestore field names (`local_union`, `local_name`, `email`, `phone`)
  - Construct `location` from `city` and `state` fields
  - Change `phone` getter to non-nullable `String` for safer UI usage
- Refactored `AppStateProvider` to use `LocalsRecord.fromFirestore` factory method for creating locals from Firestore documents
- Fixed Firestore queries in `FirestoreService` to order and filter by `local_union` instead of `localUnion`

### UI Improvements
- Updated `LocalsScreen` and related widgets to:
  - Check for non-empty phone strings without null checks
  - Display "Not specified" when phone is empty
  - Use non-nullable phone values safely in tap handlers

## Test plan
- [x] Verify locals list loads correctly with updated field mappings
- [x] Confirm location displays as "City, State" when both are present
- [x] Test phone number tap-to-call functionality
- [x] Ensure no runtime errors due to null phone values
- [x] Validate Firestore queries return expected results with new field names
- [x] Check UI displays "Not specified" for missing phone numbers

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/55eb98a6-2d7c-4a84-a3aa-a9551f677f81