### PR TITLE
Add interactive power outage tracking to Storm screen

### DIFF
--- a/lib/services/power_outage_service.dart
+++ b/lib/services/power_outage_service.dart
@@ -1,0 +1,252 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'cache_service.dart';
+
+/// Power outage data service using PowerOutage.us public API
+/// 
+/// Provides real-time power outage information by state for storm work planning
+/// Data is updated every 10 minutes from utility providers
+class PowerOutageService {
+  static final PowerOutageService _instance = PowerOutageService._internal();
+  factory PowerOutageService() => _instance;
+  PowerOutageService._internal();
+
+  final Dio _dio = Dio(BaseOptions(
+    headers: {
+      'User-Agent': 'JourneymanJobs/1.0 (IBEW storm work app)',
+      'Accept': 'application/json',
+    },
+  ));
+  final CacheService _cacheService = CacheService();
+  
+  // PowerOutage.us API endpoint (public key from their website)
+  static const String _apiUrl = 'https://poweroutage.us/api/web/states';
+  static const String _apiKey = '9818916638';
+  static const String _countryId = 'us';
+  
+  // Cache configuration
+  static const Duration _cacheDuration = Duration(minutes: 5);
+  static const int _minimumOutageThreshold = 20000; // Only show states with 20k+ outages
+  
+  // Current data
+  List<PowerOutageState> _currentOutages = [];
+  Timer? _refreshTimer;
+  DateTime? _lastUpdate;
+  
+  /// Initialize the service and start periodic updates
+  Future<void> initialize() async {
+    await fetchPowerOutages();
+    
+    // Set up periodic refresh every 5 minutes
+    _refreshTimer?.cancel();
+    _refreshTimer = Timer.periodic(
+      const Duration(minutes: 5),
+      (_) => fetchPowerOutages(),
+    );
+  }
+  
+  /// Dispose of resources
+  void dispose() {
+    _refreshTimer?.cancel();
+  }
+  
+  /// Get current power outage data
+  Future<List<PowerOutageState>> getPowerOutages({
+    bool forceRefresh = false,
+  }) async {
+    if (forceRefresh || _currentOutages.isEmpty || _isDataStale()) {
+      await fetchPowerOutages();
+    }
+    
+    // Return filtered and sorted data
+    return _currentOutages
+        .where((state) => state.outageCount >= _minimumOutageThreshold)
+        .toList()
+      ..sort((a, b) => b.outageCount.compareTo(a.outageCount));
+  }
+  
+  /// Fetch latest power outage data from API
+  Future<void> fetchPowerOutages() async {
+    try {
+      final cacheKey = 'power_outages_latest';
+      
+      // Try cache first
+      final cached = await _cacheService.get<String>(cacheKey);
+      if (cached != null && !_isDataStale()) {
+        final data = jsonDecode(cached);
+        _parseOutageData(data);
+        return;
+      }
+      
+      // Fetch fresh data
+      final response = await _dio.get(
+        _apiUrl,
+        queryParameters: {
+          'key': _apiKey,
+          'countryid': _countryId,
+        },
+      );
+      
+      if (response.statusCode == 200) {
+        _parseOutageData(response.data);
+        _lastUpdate = DateTime.now();
+        
+        // Cache the data
+        await _cacheService.set(
+          cacheKey,
+          jsonEncode(response.data),
+          ttl: _cacheDuration,
+        );
+        
+        if (kDebugMode) {
+          final significantOutages = _currentOutages
+              .where((s) => s.outageCount >= _minimumOutageThreshold)
+              .length;
+          print('Power outage data updated: $significantOutages states with 20k+ outages');
+        }
+      }
+    } catch (e) {
+      if (kDebugMode) {
+        print('Error fetching power outage data: $e');
+      }
+      // Keep using cached data if available
+    }
+  }
+  
+  /// Parse outage data from API response
+  void _parseOutageData(Map<String, dynamic> data) {
+    _currentOutages.clear();
+    
+    final records = data['WebStateRecord'] as List<dynamic>?;
+    if (records != null) {
+      for (final record in records) {
+        _currentOutages.add(PowerOutageState.fromJson(record));
+      }
+    }
+  }
+  
+  /// Check if current data is stale
+  bool _isDataStale() {
+    if (_lastUpdate == null) return true;
+    return DateTime.now().difference(_lastUpdate!) > _cacheDuration;
+  }
+  
+  /// Get total outages across all states
+  int getTotalOutages() {
+    return _currentOutages.fold(0, (sum, state) => sum + state.outageCount);
+  }
+  
+  /// Get total affected customers across significant outages (20k+)
+  int getSignificantOutagesTotal() {
+    return _currentOutages
+        .where((state) => state.outageCount >= _minimumOutageThreshold)
+        .fold(0, (sum, state) => sum + state.outageCount);
+  }
+  
+  /// Get states with most severe outages
+  List<PowerOutageState> getMostAffectedStates({int limit = 5}) {
+    final sorted = List<PowerOutageState>.from(_currentOutages)
+      ..sort((a, b) => b.outageCount.compareTo(a.outageCount));
+    
+    return sorted.take(limit).toList();
+  }
+  
+  /// Calculate outage percentage for a state
+  double getOutagePercentage(PowerOutageState state) {
+    if (state.customerCount == 0) return 0;
+    return (state.outageCount / state.customerCount) * 100;
+  }
+  
+  /// Get outage severity level
+  OutageSeverity getOutageSeverity(PowerOutageState state) {
+    final percentage = getOutagePercentage(state);
+    
+    if (state.outageCount >= 100000 || percentage >= 20) {
+      return OutageSeverity.critical;
+    } else if (state.outageCount >= 50000 || percentage >= 10) {
+      return OutageSeverity.severe;
+    } else if (state.outageCount >= 20000 || percentage >= 5) {
+      return OutageSeverity.moderate;
+    } else if (state.outageCount >= 10000 || percentage >= 2) {
+      return OutageSeverity.minor;
+    } else {
+      return OutageSeverity.minimal;
+    }
+  }
+  
+  /// Get formatted outage count
+  String formatOutageCount(int count) {
+    if (count >= 1000000) {
+      return '${(count / 1000000).toStringAsFixed(1)}M';
+    } else if (count >= 1000) {
+      return '${(count / 1000).toStringAsFixed(count >= 10000 ? 0 : 1)}K';
+    }
+    return count.toString();
+  }
+  
+  /// Get last update time
+  DateTime? get lastUpdate => _lastUpdate;
+  
+  /// Check if data is loading
+  bool get isLoading => _currentOutages.isEmpty && _lastUpdate == null;
+}
+
+/// Power outage state model
+class PowerOutageState {
+  final String stateName;
+  final int outageCount;
+  final int customerCount;
+  
+  PowerOutageState({
+    required this.stateName,
+    required this.outageCount,
+    required this.customerCount,
+  });
+  
+  factory PowerOutageState.fromJson(Map<String, dynamic> json) {
+    return PowerOutageState(
+      stateName: json['StateName'] ?? '',
+      outageCount: json['OutageCount'] ?? 0,
+      customerCount: json['CustomerCount'] ?? 0,
+    );
+  }
+  
+  Map<String, dynamic> toJson() => {
+    'StateName': stateName,
+    'OutageCount': outageCount,
+    'CustomerCount': customerCount,
+  };
+  
+  /// Get state abbreviation
+  String get stateAbbreviation {
+    // Map of state names to abbreviations
+    const stateAbbreviations = {
+      'Alabama': 'AL', 'Alaska': 'AK', 'Arizona': 'AZ', 'Arkansas': 'AR',
+      'California': 'CA', 'Colorado': 'CO', 'Connecticut': 'CT', 'Delaware': 'DE',
+      'District of Columbia': 'DC', 'Florida': 'FL', 'Georgia': 'GA', 'Hawaii': 'HI',
+      'Idaho': 'ID', 'Illinois': 'IL', 'Indiana': 'IN', 'Iowa': 'IA',
+      'Kansas': 'KS', 'Kentucky': 'KY', 'Louisiana': 'LA', 'Maine': 'ME',
+      'Maryland': 'MD', 'Massachusetts': 'MA', 'Michigan': 'MI', 'Minnesota': 'MN',
+      'Mississippi': 'MS', 'Missouri': 'MO', 'Montana': 'MT', 'Nebraska': 'NE',
+      'Nevada': 'NV', 'New Hampshire': 'NH', 'New Jersey': 'NJ', 'New Mexico': 'NM',
+      'New York': 'NY', 'North Carolina': 'NC', 'North Dakota': 'ND', 'Ohio': 'OH',
+      'Oklahoma': 'OK', 'Oregon': 'OR', 'Pennsylvania': 'PA', 'Rhode Island': 'RI',
+      'South Carolina': 'SC', 'South Dakota': 'SD', 'Tennessee': 'TN', 'Texas': 'TX',
+      'Utah': 'UT', 'Vermont': 'VT', 'Virginia': 'VA', 'Washington': 'WA',
+      'West Virginia': 'WV', 'Wisconsin': 'WI', 'Wyoming': 'WY',
+    };
+    
+    return stateAbbreviations[stateName] ?? stateName;
+  }
+}
+
+/// Outage severity levels
+enum OutageSeverity {
+  minimal,   // < 10k outages
+  minor,     // 10k-20k outages
+  moderate,  // 20k-50k outages
+  severe,    // 50k-100k outages
+  critical,  // 100k+ outages
+}

--- a/lib/widgets/storm/power_outage_card.dart
+++ b/lib/widgets/storm/power_outage_card.dart
@@ -1,0 +1,359 @@
+import 'package:flutter/material.dart';
+import '../../design_system/app_theme.dart';
+import '../../services/power_outage_service.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+/// Widget to display power outage information for a state
+class PowerOutageCard extends StatelessWidget {
+  final PowerOutageState outageData;
+  final VoidCallback? onTap;
+  
+  const PowerOutageCard({
+    Key? key,
+    required this.outageData,
+    this.onTap,
+  }) : super(key: key);
+  
+  @override
+  Widget build(BuildContext context) {
+    final service = PowerOutageService();
+    final severity = service.getOutageSeverity(outageData);
+    final percentage = service.getOutagePercentage(outageData);
+    
+    return Container(
+      margin: const EdgeInsets.only(bottom: AppTheme.spacingMd),
+      decoration: BoxDecoration(
+        color: AppTheme.white,
+        borderRadius: BorderRadius.circular(AppTheme.radiusMd),
+        boxShadow: [AppTheme.shadowSm],
+        border: Border.all(
+          color: _getSeverityColor(severity),
+          width: 2,
+        ),
+      ),
+      child: Material(
+        color: Colors.transparent,
+        borderRadius: BorderRadius.circular(AppTheme.radiusMd),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(AppTheme.radiusMd),
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.all(AppTheme.spacingMd),
+            child: Column(
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // State icon
+                    Container(
+                      width: 56,
+                      height: 56,
+                      decoration: BoxDecoration(
+                        color: _getSeverityColor(severity).withOpacity(0.1),
+                        borderRadius: BorderRadius.circular(AppTheme.radiusSm),
+                      ),
+                      child: Center(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(
+                              FontAwesomeIcons.bolt,
+                              color: _getSeverityColor(severity),
+                              size: 24,
+                            ),
+                            Text(
+                              outageData.stateAbbreviation,
+                              style: AppTheme.labelSmall.copyWith(
+                                color: _getSeverityColor(severity),
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: AppTheme.spacingMd),
+                    
+                    // State info
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            outageData.stateName,
+                            style: AppTheme.headlineSmall.copyWith(
+                              color: AppTheme.primaryNavy,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: AppTheme.spacingXs),
+                          Row(
+                            children: [
+                              Icon(
+                                FontAwesomeIcons.usersSlash,
+                                size: 14,
+                                color: AppTheme.textSecondary,
+                              ),
+                              const SizedBox(width: AppTheme.spacingXs),
+                              Text(
+                                '${service.formatOutageCount(outageData.outageCount)} without power',
+                                style: AppTheme.bodyMedium.copyWith(
+                                  color: AppTheme.textPrimary,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                    
+                    // Severity indicator
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: AppTheme.spacingSm,
+                            vertical: AppTheme.spacingXs,
+                          ),
+                          decoration: BoxDecoration(
+                            color: _getSeverityColor(severity),
+                            borderRadius: BorderRadius.circular(AppTheme.radiusXs),
+                          ),
+                          child: Text(
+                            _getSeverityLabel(severity),
+                            style: AppTheme.labelSmall.copyWith(
+                              color: AppTheme.white,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: AppTheme.spacingXs),
+                        Text(
+                          '${percentage.toStringAsFixed(1)}%',
+                          style: AppTheme.headlineMedium.copyWith(
+                            color: _getSeverityColor(severity),
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+                
+                const SizedBox(height: AppTheme.spacingMd),
+                
+                // Progress bar
+                Container(
+                  height: 8,
+                  decoration: BoxDecoration(
+                    color: AppTheme.lightGray,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(4),
+                    child: LinearProgressIndicator(
+                      value: percentage / 100,
+                      backgroundColor: Colors.transparent,
+                      valueColor: AlwaysStoppedAnimation<Color>(
+                        _getSeverityColor(severity),
+                      ),
+                    ),
+                  ),
+                ),
+                
+                const SizedBox(height: AppTheme.spacingSm),
+                
+                // Stats row
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      'Total customers: ${service.formatOutageCount(outageData.customerCount)}',
+                      style: AppTheme.bodySmall.copyWith(
+                        color: AppTheme.textMuted,
+                      ),
+                    ),
+                    Row(
+                      children: [
+                        Icon(
+                          FontAwesomeIcons.circleExclamation,
+                          size: 12,
+                          color: AppTheme.warningYellow,
+                        ),
+                        const SizedBox(width: 4),
+                        Text(
+                          'Storm restoration needed',
+                          style: AppTheme.bodySmall.copyWith(
+                            color: AppTheme.warningYellow,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+  
+  Color _getSeverityColor(OutageSeverity severity) {
+    switch (severity) {
+      case OutageSeverity.critical:
+        return Color(0xFFD8006D); // Magenta
+      case OutageSeverity.severe:
+        return AppTheme.errorRed;
+      case OutageSeverity.moderate:
+        return AppTheme.warningYellow;
+      case OutageSeverity.minor:
+        return Colors.orange;
+      case OutageSeverity.minimal:
+        return AppTheme.textMuted;
+    }
+  }
+  
+  String _getSeverityLabel(OutageSeverity severity) {
+    switch (severity) {
+      case OutageSeverity.critical:
+        return 'CRITICAL';
+      case OutageSeverity.severe:
+        return 'SEVERE';
+      case OutageSeverity.moderate:
+        return 'MODERATE';
+      case OutageSeverity.minor:
+        return 'MINOR';
+      case OutageSeverity.minimal:
+        return 'MINIMAL';
+    }
+  }
+}
+
+/// Widget to display power outage summary
+class PowerOutageSummary extends StatelessWidget {
+  final List<PowerOutageState> outages;
+  
+  const PowerOutageSummary({
+    Key? key,
+    required this.outages,
+  }) : super(key: key);
+  
+  @override
+  Widget build(BuildContext context) {
+    final service = PowerOutageService();
+    final totalAffected = service.getSignificantOutagesTotal();
+    final stateCount = outages.length;
+    
+    return Container(
+      padding: const EdgeInsets.all(AppTheme.spacingLg),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            AppTheme.errorRed.withOpacity(0.9),
+            AppTheme.warningYellow.withOpacity(0.9),
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(AppTheme.radiusLg),
+        boxShadow: [AppTheme.shadowMd],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                FontAwesomeIcons.plugCircleXmark,
+                color: AppTheme.white,
+                size: 28,
+              ),
+              const SizedBox(width: AppTheme.spacingMd),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'MAJOR POWER OUTAGES',
+                      style: AppTheme.titleLarge.copyWith(
+                        color: AppTheme.white,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    Text(
+                      'Restoration crews needed nationwide',
+                      style: AppTheme.bodyMedium.copyWith(
+                        color: AppTheme.white.withOpacity(0.9),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppTheme.spacingLg),
+          Row(
+            children: [
+              Expanded(
+                child: _buildStatCard(
+                  icon: FontAwesomeIcons.usersSlash,
+                  value: service.formatOutageCount(totalAffected),
+                  label: 'Customers Affected',
+                ),
+              ),
+              const SizedBox(width: AppTheme.spacingMd),
+              Expanded(
+                child: _buildStatCard(
+                  icon: FontAwesomeIcons.mapLocationDot,
+                  value: stateCount.toString(),
+                  label: 'States Impacted',
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+  
+  Widget _buildStatCard({
+    required IconData icon,
+    required String value,
+    required String label,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(AppTheme.spacingMd),
+      decoration: BoxDecoration(
+        color: AppTheme.white.withOpacity(0.2),
+        borderRadius: BorderRadius.circular(AppTheme.radiusMd),
+      ),
+      child: Column(
+        children: [
+          Icon(
+            icon,
+            color: AppTheme.white,
+            size: 24,
+          ),
+          const SizedBox(height: AppTheme.spacingSm),
+          Text(
+            value,
+            style: AppTheme.displaySmall.copyWith(
+              color: AppTheme.white,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          Text(
+            label,
+            style: AppTheme.bodySmall.copyWith(
+              color: AppTheme.white.withOpacity(0.9),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Introduces a new PowerOutageService to fetch and cache real-time power outage data from PowerOutage.us API
- Adds interactive PowerOutageCard widgets to display major power outages by state within the Storm screen
- Implements a detailed modal bottom sheet for each outage with stats, severity, and actionable buttons for jobs and unions
- Enhances UI with PowerOutageSummary banner showing total affected customers and states impacted

## Changes

### Core Functionality
- Created `PowerOutageService` singleton for fetching, caching, and processing outage data
- Added `PowerOutageState` model and `OutageSeverity` enum for structured outage info
- Implemented periodic data refresh every 5 minutes with caching to reduce API calls

### UI Components
- Developed `PowerOutageCard` widget to visually represent outage severity, affected customers, and percentage
- Added `PowerOutageSummary` widget to highlight nationwide outage impact
- Integrated outage section into `StormScreen` with loading states and region filtering
- Modal bottom sheet shows detailed outage info, restoration urgency, and navigation options for storm work opportunities

### Code Integration
- Imported and initialized `PowerOutageService` in `StormScreen` state lifecycle
- Added disposal of service resources on widget teardown
- Connected UI tap events to show detailed outage modal

## Test plan
- [x] Verify power outage data loads and updates on Storm screen
- [x] Confirm outage cards display correct severity and counts
- [x] Test modal bottom sheet opens with accurate details and buttons
- [x] Ensure periodic refresh updates data without UI disruption
- [x] Validate caching prevents excessive API requests
- [x] Check UI responsiveness and error handling when data fetch fails

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/62dc8efe-cf1c-4677-bdf7-a64bd4b06b11